### PR TITLE
Add PlayerTrails component

### DIFF
--- a/src/Client/Player/ClientPlayer.luau
+++ b/src/Client/Player/ClientPlayer.luau
@@ -22,6 +22,9 @@ type PlayerOptions = PlayerOptions.PlayerOptions
 local PlayerRevives = require(ReplicatedStorage.Common.Revives.PlayerRevives)
 type PlayerRevives = PlayerRevives.PlayerRevives
 
+local PlayerTrails = require(ReplicatedStorage.Common.Trails.PlayerTrails)
+type PlayerTrails = PlayerTrails.PlayerTrails
+
 export type ClientPlayer = {
     JoinTime: number,
 
@@ -30,6 +33,7 @@ export type ClientPlayer = {
     Bombs: PlayerBombs,
     Revives: PlayerRevives,
     Options: PlayerOptions,
+    Trails: PlayerTrails,
 }
 
 local function ClientPlayer(scope: Scope, joinTime: number, data: PlayerData): ClientPlayer
@@ -41,6 +45,7 @@ local function ClientPlayer(scope: Scope, joinTime: number, data: PlayerData): C
         Bombs = PlayerBombs(scope, data.Bombs),
         Revives = PlayerRevives(scope, data.Revives),
         Options = PlayerOptions(scope, data.Options),
+        Trails = PlayerTrails(scope, data.Trails),
     }
 
     return self

--- a/src/Common/Trails/PlayerTrails.luau
+++ b/src/Common/Trails/PlayerTrails.luau
@@ -1,0 +1,111 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Packages = ReplicatedStorage.Packages
+local Common = ReplicatedStorage.Common
+
+local Fusion = require(Packages.Fusion)
+local peek = Fusion.peek
+type Scope = Fusion.Scope<typeof(Fusion)>
+type Value<T> = Fusion.Value<T>
+
+local TrailsData = require(Common.Trails.TrailsData)
+type TrailsData = TrailsData.TrailsData
+
+type TrailId = string
+
+local function cloneOwnedIds(owned: {TrailId}?): {TrailId}
+    local cloned: {TrailId} = {}
+
+    if owned then
+        for index, trailId in owned do
+            cloned[index] = trailId
+        end
+    end
+
+    return cloned
+end
+
+export type PlayerTrails = {
+    EquippedId: Value<TrailId?>,
+    OwnedIds: Value<{TrailId}>,
+
+    Equip: (trailId: TrailId) -> (),
+    Unequip: () -> (),
+    Owns: (trailId: TrailId) -> boolean,
+    AddOwnedTrail: (trailId: TrailId) -> (),
+}
+
+local function PlayerTrails(scope: Scope, data: TrailsData): PlayerTrails
+    local equippedId = scope:Value(data.EquippedId)
+    local ownedIds = scope:Value(cloneOwnedIds(data.OwnedIds))
+
+    local function updateEquipped()
+        if not RunService:IsServer() then
+            return
+        end
+
+        data.EquippedId = peek(equippedId)
+    end
+
+    local function updateOwned()
+        if not RunService:IsServer() then
+            return
+        end
+
+        data.OwnedIds = cloneOwnedIds(peek(ownedIds))
+    end
+
+    if RunService:IsServer() then
+        updateEquipped()
+        updateOwned()
+
+        scope:Observer(equippedId):onChange(updateEquipped)
+        scope:Observer(ownedIds):onChange(updateOwned)
+    end
+
+    local function Equip(trailId: TrailId)
+        equippedId:set(trailId)
+        updateEquipped()
+    end
+
+    local function Unequip()
+        equippedId:set(nil)
+        updateEquipped()
+    end
+
+    local function Owns(trailId: TrailId): boolean
+        for _, ownedId in peek(ownedIds) do
+            if ownedId == trailId then
+                return true
+            end
+        end
+
+        return false
+    end
+
+    local function AddOwnedTrail(trailId: TrailId)
+        if Owns(trailId) then
+            return
+        end
+
+        local currentOwned = cloneOwnedIds(peek(ownedIds))
+        table.insert(currentOwned, trailId)
+        ownedIds:set(currentOwned)
+        updateOwned()
+    end
+
+    local self: PlayerTrails = {
+        EquippedId = equippedId,
+        OwnedIds = ownedIds,
+
+        Equip = Equip,
+        Unequip = Unequip,
+        Owns = Owns,
+        AddOwnedTrail = AddOwnedTrail,
+    }
+
+    return self
+end
+
+return PlayerTrails

--- a/src/Server/Player/ServerPlayer.luau
+++ b/src/Server/Player/ServerPlayer.luau
@@ -25,6 +25,9 @@ type PlayerLevel = PlayerLevel.PlayerLevel
 local PlayerRevives = require(Common.Revives.PlayerRevives)
 type PlayerRevives = PlayerRevives.PlayerRevives
 
+local PlayerTrails = require(Common.Trails.PlayerTrails)
+type PlayerTrails = PlayerTrails.PlayerTrails
+
 export type ServerPlayer = {
     Scope: UnknownScope,
     Player: Player,
@@ -35,6 +38,7 @@ export type ServerPlayer = {
     Options: PlayerOptions,
     Level: PlayerLevel,
     Revives: PlayerRevives,
+    Trails: PlayerTrails,
 }
 
 local function ServerPlayer(scope: FusionScope, player: Player, joinTime: number, data: PlayerData): ServerPlayer
@@ -43,6 +47,7 @@ local function ServerPlayer(scope: FusionScope, player: Player, joinTime: number
     local options = PlayerOptions(scope, data.Options)
     local level = PlayerLevel(scope, data.Level)
     local revives = PlayerRevives(scope, data.Revives)
+    local trails = PlayerTrails(scope, data.Trails)
 
     local self: ServerPlayer = {
         Scope = scope,
@@ -54,6 +59,7 @@ local function ServerPlayer(scope: FusionScope, player: Player, joinTime: number
         Options = options,
         Level = level,
         Revives = revives,
+        Trails = trails,
     }
 
     return self


### PR DESCRIPTION
## Summary
- add a PlayerTrails Fusion component to encapsulate equipped and owned trail state with helper APIs
- wire the new PlayerTrails component into both the client and server player compositions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5d67bacc0832ca8bd5ae0de09bbbd