### PR TITLE
Add Blink structs for player level rewards and revives

### DIFF
--- a/blink/LevelRewards.blink
+++ b/blink/LevelRewards.blink
@@ -1,0 +1,3 @@
+struct LevelRewardsData {
+    ClaimedIndexes: map {[i32]: bool},
+}

--- a/blink/Player.blink
+++ b/blink/Player.blink
@@ -1,15 +1,19 @@
+import "./Bombs.blink"
 import "./Coins.blink"
 import "./Level.blink"
+import "./LevelRewards.blink"
 import "./Options.blink"
-import "./Bombs.blink"
 import "./Quests.blink"
+import "./Revives.blink"
 import "./Trails.blink"
 
 struct PlayerData {
+    Bombs: Bombs.BombsData,
     Coins: Coins.CoinsData,
     Level: Level.LevelData,
+    LevelRewards: LevelRewards.LevelRewardsData,
     Options: Options.OptionsData,
-    Bombs: Bombs.BombsData,
     Quests: Quests.QuestsData,
+    Revives: Revives.RevivesData,
     Trails: Trails.TrailsData,
 }

--- a/blink/Revives.blink
+++ b/blink/Revives.blink
@@ -1,0 +1,3 @@
+struct RevivesData {
+    Revives: i32,
+}


### PR DESCRIPTION
## Summary
- add Blink schemas for the player LevelRewards and Revives components
- include the missing component fields in the PlayerData initial payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6834adec8832c932efef7fa127bd2